### PR TITLE
Return the correct number of document for each collection

### DIFF
--- a/mongo_docs
+++ b/mongo_docs
@@ -36,17 +36,13 @@ def doData():
 def doConfig():
 
     print "graph_title MongoDB documents count"
-    print "graph_args --base 1000 -l 0"
-    print "graph_vlabel documents count"
+    print "graph_args --base 1000 -l 0 --vertical-label Docs"
     print "graph_category MongoDB"
 
     ss = getDatabasesStats()
     for k,v in ss.iteritems():
         for a,b in v.iteritems():
             print str(k)+str(a) + ".label " + str(k) + " " + str(a)
-            print str(k)+str(a) + ".min 0"
-            print str(k)+str(a) + ".type COUNTER"
-            print str(k)+str(a) + ".max 500000"
             print str(k)+str(a) + ".draw LINE1"
 
 if __name__ == "__main__":

--- a/mongo_docs
+++ b/mongo_docs
@@ -7,33 +7,47 @@ import sys
 import os
 import pymongo
 
-def getServerStatus():
+def getDatabasesStats():
     host = "127.0.0.1"
     port = 27017
     c = pymongo.MongoClient(host, port)
-    return c.admin.command('serverStatus', workingSet=True)
+
+    dbs = {}
+    for k in c.database_names():
+        if k != "admin" and k != "local" and k != "":
+            db = c[k]
+            dbs[k] = {}
+            for coll in db.collection_names():
+                if '.' not in coll:
+                    dbs[k][coll] = db[coll].count()
+
+    return dbs
 
 name = "documents"
 
 
 def doData():
-    ss = getServerStatus()
-    for k,v in ss["metrics"]["document"].iteritems():
-        print( str(k) + ".value " + str(v) )
+    ss = getDatabasesStats()
+    for k,v in ss.iteritems():
+        for a,b in v.iteritems():
+            print(str(k)+str(a) + ".value " + str(b))
+
 
 def doConfig():
 
-    print "graph_title MongoDB documents"
+    print "graph_title MongoDB documents count"
     print "graph_args --base 1000 -l 0"
-    print "graph_vlabel documents"
+    print "graph_vlabel documents count"
     print "graph_category MongoDB"
 
-    for k in getServerStatus()["metrics"]["document"]:
-        print k + ".label " + k
-        print k + ".min 0"
-        print k + ".type COUNTER"
-        print k + ".max 500000"
-        print k + ".draw LINE1"
+    ss = getDatabasesStats()
+    for k,v in ss.iteritems():
+        for a,b in v.iteritems():
+            print str(k)+str(a) + ".label " + str(k) + " " + str(a)
+            print str(k)+str(a) + ".min 0"
+            print str(k)+str(a) + ".type COUNTER"
+            print str(k)+str(a) + ".max 500000"
+            print str(k)+str(a) + ".draw LINE1"
 
 if __name__ == "__main__":
 


### PR DESCRIPTION
The mongo_docs plugin was not returning count of collections, but the Numbers of actions (inserting, updating...).
Now the plugin return, for every collections, the correct number of
documents.
