### PR TITLE
ability to set host/port via env vars

### DIFF
--- a/mongo_btree
+++ b/mongo_btree
@@ -7,9 +7,10 @@ import sys
 import os  
 import pymongo
 
+host = "127.0.0.1"
+port = 27017
+
 def getServerStatus():
-    host = "127.0.0.1"
-    port = 27017
     c = pymongo.MongoClient(host, port)
     return c.admin.command('serverStatus', workingSet=True)
 

--- a/mongo_conn
+++ b/mongo_conn
@@ -7,9 +7,10 @@ import sys
 import os  
 import pymongo
 
+host = "127.0.0.1"
+port = 27017
+
 def getServerStatus():
-    host = "127.0.0.1"
-    port = 27017
     c = pymongo.MongoClient(host, port)
     return c.admin.command('serverStatus', workingSet=True)
 

--- a/mongo_lock
+++ b/mongo_lock
@@ -7,9 +7,10 @@ import sys
 import os  
 import pymongo
 
+host = "127.0.0.1"
+port = 27017
+
 def getServerStatus():
-    host = "127.0.0.1"
-    port = 27017
     c = pymongo.MongoClient(host, port)
     return c.admin.command('serverStatus', workingSet=True)
 

--- a/mongo_mem
+++ b/mongo_mem
@@ -7,9 +7,10 @@ import sys
 import os  
 import pymongo
 
+host = "127.0.0.1"
+port = 27017
+
 def getServerStatus():
-    host = "127.0.0.1"
-    port = 27017
     c = pymongo.MongoClient(host, port)
     return c.admin.command('serverStatus', workingSet=True)
 

--- a/mongo_ops
+++ b/mongo_ops
@@ -7,9 +7,10 @@ import sys
 import os  
 import pymongo
 
+host = "127.0.0.1"
+port = 27017
+
 def getServerStatus():
-    host = "127.0.0.1"
-    port = 27017
     c = pymongo.MongoClient(host, port)
     return c.admin.command('serverStatus', workingSet=True)
 

--- a/src/header.py
+++ b/src/header.py
@@ -4,8 +4,9 @@ import sys
 import os  
 import pymongo
 
+host = "127.0.0.1"
+port = 27017
+
 def getServerStatus():
-    host = "127.0.0.1"
-    port = 27017
     c = pymongo.MongoClient(host, port)
     return c.admin.command('serverStatus', workingSet=True)


### PR DESCRIPTION
Looks like this option was broken with this commit:
https://github.com/comerford/mongo-munin/commit/370a2f66f5f93d66030a3e1a766b0bf97a31d852#diff-b0dced00615b709b7dc70a2a084f24b2L16